### PR TITLE
Fix/sidebar

### DIFF
--- a/components/header/GNB.tsx
+++ b/components/header/GNB.tsx
@@ -34,8 +34,8 @@ const GNB = () => {
     <header>
       <nav className={gnb['nav']} ref={gnbRef}>
         <ul>
-          <li className={gnb['mobile-nav']}>
-            <label htmlFor="mobile_nav" tabIndex={0}>
+          <li className={gnb['sidebar']}>
+            <label htmlFor="sidebar" tabIndex={0}>
               <RiMenuAddLine size={'1.2rem'} color={'inherit'} />
             </label>
           </li>

--- a/components/header/GNB.tsx
+++ b/components/header/GNB.tsx
@@ -2,7 +2,7 @@
 import { useRef, useEffect } from 'react';
 import getConfig from 'next/config';
 import Link from 'next/link';
-import Sidebar from './sidebar';
+import Sidebar from '@/components/header/sidebar';
 import { RiMenuAddLine } from 'react-icons/ri';
 import { SiGooglesheets } from 'react-icons/si';
 import gnb from '@/styles/header/GNB.module.scss';

--- a/components/header/sidebar.tsx
+++ b/components/header/sidebar.tsx
@@ -8,7 +8,7 @@ const { publicRuntimeConfig } = getConfig();
 const Sidebar = () => {
   return (
     <div>
-      <input type="checkBox" id="mobile_nav" className={mobileNav['check-box']} />
+      <input type="checkBox" id="sidebar" className={mobileNav['check-box']} />
       <div className={mobileNav['container']}>
         <div className={mobileNav['sidebar']}>
           <ul>
@@ -21,11 +21,11 @@ const Sidebar = () => {
               </Link>
             </li>
           </ul>
-          <label htmlFor="mobile_nav" className={mobileNav['close']}>
+          <label htmlFor="sidebar" className={mobileNav['close']}>
             <FaWindowClose size={'2rem'} color="inherit" />
           </label>
         </div>
-        <label htmlFor="mobile_nav" className={mobileNav['back-drop']} />
+        <label htmlFor="sidebar" className={mobileNav['back-drop']} />
       </div>
     </div>
   );

--- a/components/home/youtube_section.tsx
+++ b/components/home/youtube_section.tsx
@@ -1,6 +1,6 @@
 import { UpcomingData } from '@/models/sheet/in_sheet';
 import home from '@/styles/Home.module.scss';
-import YoutubeContent from '../youtube_content';
+import YoutubeContent from '@/components/youtube_content';
 
 interface YoutubeSectionProps {
   contents: UpcomingData[];

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,18 +1,19 @@
 import Image from 'next/image';
 import loading from '@/styles/loading.module.scss';
 import { AiOutlineLoading } from 'react-icons/ai';
+import loadingImage from '/public/loading.png';
 
 const Loading = () => {
   return (
     <div className={loading['loading']}>
       <div>
-        <div style={{ border: 'none' }}>
+        <div>
           <Image
-            src="/loading.png"
+            src={loadingImage}
             width={100}
             height={100}
             alt="loading_img"
-            style={{ border: 'none' }}
+            placeholder="blur"
             unoptimized
             priority
           />

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -7,7 +7,15 @@ const Loading = () => {
     <div className={loading['loading']}>
       <div>
         <div style={{ border: 'none' }}>
-          <Image src="/loading.png" width={100} height={100} alt="loading_img" unoptimized style={{ border: 'none' }} />
+          <Image
+            src="/loading.png"
+            width={100}
+            height={100}
+            alt="loading_img"
+            style={{ border: 'none' }}
+            unoptimized
+            priority
+          />
           <AiOutlineLoading size={130} color={'inherit'} />
         </div>
         <h2>Loading Now!</h2>

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,22 +1,13 @@
 import Image from 'next/image';
 import loading from '@/styles/loading.module.scss';
 import { AiOutlineLoading } from 'react-icons/ai';
-import loadingImage from '/public/loading.png';
 
 const Loading = () => {
   return (
     <div className={loading['loading']}>
       <div>
         <div>
-          <Image
-            src={loadingImage}
-            width={100}
-            height={100}
-            alt="loading_img"
-            placeholder="blur"
-            unoptimized
-            priority
-          />
+          <Image src="/loading.png" width={100} height={100} alt="loading_img" unoptimized priority />
           <AiOutlineLoading size={130} color={'inherit'} />
         </div>
         <h2>Loading Now!</h2>

--- a/components/loading.tsx
+++ b/components/loading.tsx
@@ -1,13 +1,14 @@
 import Image from 'next/image';
 import loading from '@/styles/loading.module.scss';
 import { AiOutlineLoading } from 'react-icons/ai';
+import loadingImage from '@/public/loading.png';
 
 const Loading = () => {
   return (
     <div className={loading['loading']}>
       <div>
         <div>
-          <Image src="/loading.png" width={100} height={100} alt="loading_img" unoptimized priority />
+          <Image src={loadingImage} width={100} height={100} alt="loading_img" unoptimized priority />
           <AiOutlineLoading size={130} color={'inherit'} />
         </div>
         <h2>Loading Now!</h2>

--- a/components/service_layout.tsx
+++ b/components/service_layout.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import { ReactNode } from 'react';
 import Head from 'next/head';
-import GNB from './header/GNB';
+import GNB from '@/components/header/GNB';
 import { TfiArrowCircleUp } from 'react-icons/tfi';
-import Loading from './loading';
+import Loading from '@/components/loading';
 import useUpcommingData from '@/hooks/useUpcommingData';
 import getConfig from 'next/config';
 import home from '@/styles/Home.module.scss';
@@ -47,7 +47,6 @@ const ServiceLayout = ({
           rel="icon"
           href="https://img.icons8.com/external-microdots-premium-microdot-graphic/64/null/external-holiday-christmas-new-year-vol2-microdots-premium-microdot-graphic-4.png"
         />
-        <link rel="preload" as="image" href="/loading.png" />
       </Head>
       <GNB />
       {upcomingDataLoading || allDataLoading ? <Loading /> : null}

--- a/components/service_layout.tsx
+++ b/components/service_layout.tsx
@@ -47,6 +47,7 @@ const ServiceLayout = ({
           rel="icon"
           href="https://img.icons8.com/external-microdots-premium-microdot-graphic/64/null/external-holiday-christmas-new-year-vol2-microdots-premium-microdot-graphic-4.png"
         />
+        <link rel="preload" as="image" href="/loading.png" />
       </Head>
       <GNB />
       {upcomingDataLoading || allDataLoading ? <Loading /> : null}

--- a/components/service_layout.tsx
+++ b/components/service_layout.tsx
@@ -47,7 +47,6 @@ const ServiceLayout = ({
           rel="icon"
           href="https://img.icons8.com/external-microdots-premium-microdot-graphic/64/null/external-holiday-christmas-new-year-vol2-microdots-premium-microdot-graphic-4.png"
         />
-        <link rel="preload" as="image" href="/loading.png" />
       </Head>
       <GNB />
       {upcomingDataLoading || allDataLoading ? <Loading /> : null}

--- a/components/youtube_content.tsx
+++ b/components/youtube_content.tsx
@@ -41,6 +41,8 @@ const YoutubeContent = ({ contents }: YoutubeContentProps) => {
                 ref={imgRef}
                 onLoad={handleImgValidity}
                 onError={() => setImgLoaded(false)}
+                placeholder="blur"
+                blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mPMiCuoBwAEIwG3Vpkr7gAAAABJRU5ErkJggg=="
                 unoptimized
                 fill
               />

--- a/hooks/useAllData.ts
+++ b/hooks/useAllData.ts
@@ -1,6 +1,6 @@
 import { UpcomingData } from '@/models/sheet/in_sheet';
 import useSWR from 'swr';
-import { fetcher } from './fetcher';
+import { fetcher } from '@/hooks/fetcher';
 
 const useAllData = () => {
   const { data, error, mutate, isLoading } = useSWR(

--- a/hooks/useUpcommingData.ts
+++ b/hooks/useUpcommingData.ts
@@ -1,6 +1,6 @@
 import { UpcomingData } from '@/models/sheet/in_sheet';
 import useSWR from 'swr';
-import { fetcher } from './fetcher';
+import { fetcher } from '@/hooks/fetcher';
 
 const useUpcommingData = () => {
   const { data, error, mutate, isLoading } = useSWR(

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { NextPage } from 'next';
-import { UpcomingData } from '../models/sheet/in_sheet';
+import { UpcomingData } from '@/models/sheet/in_sheet';
 import useUpcommingData from '@/hooks/useUpcommingData';
 import home from '@/styles/Home.module.scss';
 import useAllData from '@/hooks/useAllData';

--- a/styles/header/GNB.module.scss
+++ b/styles/header/GNB.module.scss
@@ -35,7 +35,7 @@
     align-items: center;
     color: map-get($colors, light-font);
 
-    .mobile-nav {
+    .sidebar {
       margin-left: 1rem;
 
       label {

--- a/styles/header/sidebar.module.scss
+++ b/styles/header/sidebar.module.scss
@@ -6,10 +6,12 @@
 
   &:checked ~ .container {
     visibility: visible;
-    opacity: 1;
 
     .sidebar {
       transform: translateX(0%);
+    }
+    .back-drop {
+      opacity: 1;
     }
   }
 }
@@ -20,12 +22,9 @@
   left: 0;
   z-index: 500;
   visibility: hidden;
-  opacity: 0;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
   height: 100vh;
-
-  @include transition(all, 0.3s, linear);
+  @include transition(visibility, 0.3s, linear);
 
   .sidebar {
     position: relative;
@@ -70,5 +69,8 @@
     width: 100%;
     height: 100%;
     cursor: pointer;
+    opacity: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    @include transition(opacity, 0.3s, linear);
   }
 }

--- a/styles/header/sidebar.module.scss
+++ b/styles/header/sidebar.module.scss
@@ -8,7 +8,7 @@
     visibility: visible;
 
     .sidebar {
-      transform: translateX(0%);
+      transform: translateX(100%);
     }
     .back-drop {
       opacity: 1;
@@ -29,10 +29,9 @@
   .sidebar {
     position: relative;
     background-color: #ffd7de;
-    width: 80%;
+    width: 18rem;
     height: 100%;
-    max-width: 20rem;
-    transform: translateX(-100%);
+    left: -18rem;
     @include transition(transform, 0.3s, linear);
 
     ul {

--- a/utils/parseSheetData.ts
+++ b/utils/parseSheetData.ts
@@ -1,6 +1,6 @@
 import { rowData, UpcomingData } from '@/models/sheet/in_sheet';
 import { sheets_v4 } from 'googleapis';
-import { getinterval } from './get_time';
+import { getinterval } from '@/utils/get_time';
 
 interface ParseSheetDataType {
   data: sheets_v4.Schema$ValueRange;


### PR DESCRIPTION
Fix: 첫 랜더링시 sidebar가 transfrom css로 인해 움직이는 버그
- **sidebar container** - **transtion all** 에서 **visibility** 만으로 범위를 수정
- **sidebar position** - **transfrom: -100%** 에서 **left: -18rem** 으로 변경
- **sidebar width** - **80%** 에서 **18rem** 고정된 값으로 변경
- **opacity** - **sidebar container** 에서  **backdrop** 에 적용되게 변경

Fix: safari에서 첫 랜더링시 loading img에 white border가 보이는 버그
- loading.png에 **priority** 적용(preload)

Add: youtubeThumbnail blur효과 추가
