### PR TITLE
Dev: 유투브, 채널 카드 사이즈 고정, 스타일 리팩토링

### DIFF
--- a/components/common/NavLink.tsx
+++ b/components/common/NavLink.tsx
@@ -21,10 +21,8 @@ const NavLink = ({ href, children, modifier = '' }: NavLinkProps) => {
 
   return (
     <li>
-      <Link href={href} onClick={onClick}>
-        <button tabIndex={-1} className={isActive ? ['active', modifier].join(' ') : ''}>
-          {children}
-        </button>
+      <Link href={href} onClick={onClick} className={isActive ? ['active', modifier].join(' ') : ''}>
+        {children}
       </Link>
     </li>
   );

--- a/components/layout/PageHead.tsx
+++ b/components/layout/PageHead.tsx
@@ -66,6 +66,7 @@ const PageHead = ({ title, description, image, keywords }: PagePHeadProps) => {
         rel="icon"
         href="https://img.icons8.com/external-microdots-premium-microdot-graphic/64/null/external-holiday-christmas-new-year-vol2-microdots-premium-microdot-graphic-4.png"
       />
+      <link rel="stylesheet" href={`${siteURL}/reset.css`} />
     </Head>
   );
 };

--- a/pages/channels/index.tsx
+++ b/pages/channels/index.tsx
@@ -3,7 +3,6 @@ import { ChannelsDataType } from '@/types/inYoutube';
 import { ChannelSheetDataType, combineChannelData } from '@/utils/combineChannelData';
 import { parseChannelIDSheet } from '@/utils/parseChannelSheet';
 import { GetStaticProps } from 'next';
-import channels from '@/styles/channels/Channels.module.scss';
 import ChannelSection from '@/components/channels/ChannelSection';
 import Pagination from '@/components/common/pagination/Pagination';
 
@@ -14,10 +13,10 @@ export interface ChannelsPageProps {
 
 const ChannelsPage = ({ contents, totalLength }: ChannelsPageProps) => {
   return (
-    <section className={channels['main']}>
+    <>
       <ChannelSection contents={contents} />
       <Pagination totalLength={totalLength} />
-    </section>
+    </>
   );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,10 +33,10 @@ const HomePage: NextPage<HomePageProps> = ({ filter = 'scheduled' }) => {
   }
 
   return (
-    <section className={home['main']}>
+    <>
       <NavSection total={total} />
       <YoutubeSection contents={contents} />
-    </section>
+    </>
   );
 };
 

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -21,7 +21,7 @@ const SearchPage = ({}: SearchPageProps) => {
   }
 
   return (
-    <section className={search['main']}>
+    <>
       <SearchSection />
       {nameQuery !== '' ? (
         <section className={search['result']}>
@@ -32,7 +32,7 @@ const SearchPage = ({}: SearchPageProps) => {
       ) : null}
       <ContentSection contents={data.contents} />
       <ChannelSection channels={data.channels} />
-    </section>
+    </>
   );
 };
 

--- a/public/reset.css
+++ b/public/reset.css
@@ -1,0 +1,129 @@
+/* http://meyerweb.com/eric/tools/css/reset/ 
+   v2.0 | 20110126
+   License: none (public domain)
+*/
+
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  /* font-size: 100%; */
+  /* font: inherit; */
+  vertical-align: baseline;
+}
+/* HTML5 display-role reset for older browsers */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+body {
+  line-height: 1;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: '';
+  content: none;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}

--- a/styles/_placeholder.scss
+++ b/styles/_placeholder.scss
@@ -22,12 +22,21 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+
+  @include min-width(map-get($points, sm)) {
+    gap: 0.6rem;
+  }
+
+  @include min-width(map-get($points, md)) {
+    gap: 0.8rem;
+  }
 }
 
 %home-contents-section {
   //sm point보다 작을때 화면에 꽉차도록 100%
-  width: 100%;
-  margin: auto;
+  padding: 0 0.5rem;
+  width: calc(100% - 1rem);
+  margin: 0 auto;
   display: grid;
   row-gap: 0.5rem;
 
@@ -35,26 +44,22 @@
     width: auto;
     grid-template-columns: repeat(3, 1fr);
     column-gap: 0.4rem;
-    row-gap: 1.2rem;
+    row-gap: 0.8rem;
   }
 
   @include min-width(map-get($points, md)) {
-    column-gap: 2rem;
-    row-gap: 2.5rem;
+    column-gap: 3rem;
+    row-gap: 3.5rem;
     padding: 1rem;
   }
 
   @include min-width(map-get($points, lg)) {
-    column-gap: 3.25rem;
-    row-gap: 4rem;
-    padding: 1.5rem;
+    column-gap: 4.5rem;
+    row-gap: 5rem;
   }
 
   @include min-width(map-get($points, 2xl)) {
     grid-template-columns: repeat(4, 1fr);
-    column-gap: 3.5rem;
-    row-gap: 4.25rem;
-    padding: 2rem;
   }
 
   @include min-width(map-get($points, full)) {
@@ -63,14 +68,20 @@
 }
 
 %channels-channel-section {
+  width: calc(100% - 1rem);
+  padding: 0.5rem;
   display: grid;
   gap: 0.75rem;
 
-  @include min-width($mixin-middle-width) {
+  @include min-width(map-get($points, sm)) {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @include min-width($mixin-xl-width) {
+  @include min-width(950px) {
     grid-template-columns: repeat(3, 1fr);
+  }
+
+  @include min-width(map-get($points, 2xl)) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/styles/channels/Channels.module.scss
+++ b/styles/channels/Channels.module.scss
@@ -2,19 +2,6 @@
 @import 'mixin';
 @import 'placeholder';
 
-.main {
-  padding: 0.5rem;
-  margin: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-
-  @include min-width(map-get($points, md)) {
-    padding: 1rem;
-    width: 90%;
-  }
-
-  .channel-section {
-    @extend %channels-channel-section;
-  }
+.channel-section {
+  @extend %channels-channel-section;
 }

--- a/styles/common/ChannelCard.module.scss
+++ b/styles/common/ChannelCard.module.scss
@@ -11,6 +11,11 @@
   cursor: pointer;
   @include transition(scale, 0.2s, linear);
 
+  @include min-width(950px) {
+    width: 17rem;
+    margin: 0 auto;
+  }
+
   &:hover {
     transform: scale(1.02);
   }

--- a/styles/common/Pagination.module.scss
+++ b/styles/common/Pagination.module.scss
@@ -3,11 +3,17 @@
 @import '@/styles/placeholder.scss';
 
 .pagination {
-  padding: 0.5rem;
+  padding: 0.25rem;
   display: flex;
   margin: auto;
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+
+  @include min-width($mixin-middle-width) {
+    padding: 0.5rem;
+  }
 
   li {
     a {

--- a/styles/common/YoutubeContentCard.module.scss
+++ b/styles/common/YoutubeContentCard.module.scss
@@ -9,6 +9,8 @@
   @include box-shadow();
 
   @include min-width(map-get($points, sm)) {
+    width: 12rem;
+    margin: 0 auto;
     @include transition(all, 150ms, $bezier-curve);
 
     &:hover {
@@ -17,7 +19,7 @@
   }
 
   @include min-width(map-get($points, md)) {
-    transform: scale(1.1);
+    transform: scale(1.2);
 
     &:hover {
       transform: scale(1.12);
@@ -25,10 +27,10 @@
   }
 
   @include min-width(map-get($points, lg)) {
-    transform: scale(1.2);
+    transform: scale(1.3);
 
     &:hover {
-      transform: scale(1.22);
+      transform: scale(1.33);
     }
   }
 
@@ -42,6 +44,7 @@
 
   .content {
     display: flex;
+    margin: 0 auto;
     gap: 0.8rem;
 
     @include min-width(map-get($points, sm)) {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -4,9 +4,6 @@
 @import 'placeholder';
 
 %background-side {
-  @include check-device() {
-    display: none;
-  }
   z-index: -1;
   width: 10%;
   background-size: cover;
@@ -16,6 +13,10 @@
   margin: 0;
   opacity: 0;
   @include transition(opacity, 0.3s, linear);
+
+  @include check-device() {
+    display: none;
+  }
 
   @include min-width($mixin-2xl-width) {
     opacity: 1;
@@ -31,6 +32,7 @@ body {
   font-family: 'Noto Sans KR', sans-serif;
   @extend %scroll-bar;
 }
+
 a,
 h1,
 h2,
@@ -84,8 +86,8 @@ body {
   background-image: url("data:image/svg+xml,%3Csvg width='150' height='150' viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M81.28 88H68.413l19.298 19.298L81.28 88zm2.107 0h13.226L90 107.838 83.387 88zm15.334 0h12.866l-19.298 19.298L98.72 88zm-32.927-2.207L73.586 78h32.827l.5.5 7.294 7.293L115.414 87l-24.707 24.707-.707.707L64.586 87l1.207-1.207zm2.62.207L74 80.414 79.586 86H68.414zm16 0L90 80.414 95.586 86H84.414zm16 0L106 80.414 111.586 86h-11.172zm-8-6h11.173L98 85.586 92.414 80zM82 85.586L87.586 80H76.414L82 85.586zM17.414 0L.707 16.707 0 17.414V0h17.414zM4.28 0L0 12.838V0h4.28zm10.306 0L2.288 12.298 6.388 0h8.198zM180 17.414L162.586 0H180v17.414zM165.414 0l12.298 12.298L173.612 0h-8.198zM180 12.838L175.72 0H180v12.838zM0 163h16.413l.5.5 7.294 7.293L25.414 172l-8 8H0v-17zm0 10h6.613l-2.334 7H0v-7zm14.586 7l7-7H8.72l-2.333 7h8.2zM0 165.414L5.586 171H0v-5.586zM10.414 171L16 165.414 21.586 171H10.414zm-8-6h11.172L8 170.586 2.414 165zM180 163h-16.413l-7.794 7.793-1.207 1.207 8 8H180v-17zm-14.586 17l-7-7h12.865l2.333 7h-8.2zM180 173h-6.613l2.334 7H180v-7zm-21.586-2l5.586-5.586 5.586 5.586h-11.172zM180 165.414L174.414 171H180v-5.586zm-8 5.172l5.586-5.586h-11.172l5.586 5.586zM152.933 25.653l1.414 1.414-33.94 33.942-1.416-1.416 33.943-33.94zm1.414 127.28l-1.414 1.414-33.942-33.94 1.416-1.416 33.94 33.943zm-127.28 1.414l-1.414-1.414 33.94-33.942 1.416 1.416-33.943 33.94zm-1.414-127.28l1.414-1.414 33.942 33.94-1.416 1.416-33.94-33.943zM0 85c2.21 0 4 1.79 4 4s-1.79 4-4 4v-8zm180 0c-2.21 0-4 1.79-4 4s1.79 4 4 4v-8zM94 0c0 2.21-1.79 4-4 4s-4-1.79-4-4h8zm0 180c0-2.21-1.79-4-4-4s-4 1.79-4 4h8z' fill='%23ffffff' fill-opacity='0.56' fill-rule='evenodd'/%3E%3C/svg%3E");
 
   .app {
+    @extend %home-main;
     max-width: map-get($points, 2xl);
-    width: 100%;
     min-height: calc(100vh - 3.5rem - 5rem - env(safe-area-inset-top) - env(safe-area-inset-bottom));
     margin: auto;
 

--- a/styles/home/Home.module.scss
+++ b/styles/home/Home.module.scss
@@ -2,77 +2,67 @@
 @import 'mixin';
 @import 'placeholder';
 
-.main {
-  @extend %home-main;
+.nav-section {
+  display: flex;
+  justify-content: space-between;
+  color: map-get($colors, salmon);
+  font-size: 1rem;
+  font-weight: 500;
   padding: 0.5rem;
-
-  @include min-width(map-get($points, sm)) {
-    gap: 0.6rem;
-  }
 
   @include min-width(map-get($points, md)) {
     padding: 1rem;
-    gap: 0.8rem;
   }
 
-  .nav-section {
+  .nav-tab {
     display: flex;
-    justify-content: space-between;
-    color: map-get($colors, salmon);
-    font-size: 1rem;
-    font-weight: 500;
+    justify-content: space-around;
+    width: 13rem;
+    overflow: hidden;
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+    border: none;
+    border-radius: 5px;
+    @include box-shadow();
 
-    .nav-tab {
-      display: flex;
-      justify-content: space-around;
-      align-items: center;
-      width: 13rem;
-      overflow: hidden;
-      font-family: inherit;
-      font-size: inherit;
-      font-weight: inherit;
-      border: none;
-      border-radius: 5px;
-      background-color: lighten(map-get($colors, main), 10%);
-      @include box-shadow();
+    li {
+      width: 100%;
 
-      li {
+      a {
+        background-color: lighten(map-get($colors, main), 10%);
+
         width: 100%;
+        line-height: 2.4rem;
+        text-align: center;
+        @include transition(background-color, 0.2s, linear);
 
-        a {
-          &:focus-visible {
-            outline-offset: -4px;
-          }
+        &:hover {
+          background-color: map-get($colors, salmon);
+          color: lighten(map-get($colors, main), 10%);
+        }
 
-          button {
-            width: 100%;
-            height: 2.4rem;
-            text-align: center;
-            @include transition(background-color, 0.2s, linear);
+        &.active {
+          background-color: darken(map-get($colors, highlight-font), 3%);
+          color: lighten(map-get($colors, main), 10%);
+        }
 
-            &:hover {
-              background-color: map-get($colors, salmon);
-              color: lighten(map-get($colors, main), 10%);
-            }
-
-            &.active {
-              background-color: darken(map-get($colors, highlight-font), 3%);
-              color: lighten(map-get($colors, main), 10%);
-            }
-          }
+        &:focus-visible {
+          outline-offset: -4px;
         }
       }
     }
-
-    .total {
-      padding: 0.4rem;
-      background-color: lighten(map-get($colors, main), 10%);
-      border-radius: 5px;
-      @include box-shadow();
-    }
   }
 
-  .contents-section {
-    @extend %home-contents-section;
+  .total {
+    line-height: 2.4rem;
+    padding: 0 0.4rem;
+    background-color: lighten(map-get($colors, main), 10%);
+    border-radius: 5px;
+    @include box-shadow();
   }
+}
+
+.contents-section {
+  @extend %home-contents-section;
 }

--- a/styles/search/Search.module.scss
+++ b/styles/search/Search.module.scss
@@ -3,11 +3,14 @@
 @import 'placeholder';
 
 %section-layout {
-  margin: auto;
-  padding: 0.5rem;
+  width: 100%;
+  margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+
+  @include min-width(map-get($points, sm)) {
+    width: auto;
+  }
 }
 
 %section-header {
@@ -22,129 +25,128 @@
   }
 }
 
-.main {
-  @extend %home-main;
-  gap: 2rem;
+.search-section {
+  background-color: map-get($colors, bg);
 
-  .search-section {
-    background-color: map-get($colors, bg);
+  & > div:nth-child(1) {
+    margin: 0 auto;
+    width: 80%;
+    position: relative;
+    padding: 3rem 0;
 
-    & > div:nth-child(1) {
-      margin: 0 auto;
-      width: 80%;
+    form {
       position: relative;
-      padding: 3rem 0;
 
-      form {
-        position: relative;
+      label:nth-of-type(1) {
+        display: none;
+      }
 
-        label:nth-of-type(1) {
+      input {
+        padding: 1rem 1.5rem;
+        width: 100%;
+        border-radius: 30px;
+        border: none;
+        @include box-shadow();
+
+        &:focus {
+          outline: none;
+        }
+
+        &::placeholder {
+          font-family: inherit;
+          font-size: 1.25rem;
           display: none;
         }
-
-        input {
-          padding: 1rem 1.5rem;
-          width: 100%;
-          border-radius: 30px;
-          border: none;
-          @include box-shadow();
-
-          &:focus {
-            outline: none;
-          }
-
-          &::placeholder {
-            font-family: inherit;
-            font-size: 1.25rem;
-            display: none;
-          }
-        }
-
-        label:nth-of-type(2) {
-          position: absolute;
-          top: 50%;
-          transform: translateY(-50%);
-          right: 4.5rem;
-          display: flex;
-          border-radius: 100%;
-          &:hover {
-            background-color: rgba(0, 0, 0, 0.2);
-          }
-        }
-
-        button[type='submit'] {
-          position: absolute;
-          right: 1.5rem;
-          top: 50%;
-          transform: translateY(-50%);
-          display: flex;
-          padding: 0.5rem;
-          border-radius: 100%;
-          background-color: map-get($colors, salmon);
-          color: map-get($colors, light-font);
-          @include transition(background-color, 80ms, $bezier-curve);
-          @include box-shadow();
-
-          &:hover {
-            background-color: map-get($colors, hover-salmon);
-          }
-        }
       }
 
-      p {
+      label:nth-of-type(2) {
         position: absolute;
-        left: 50%;
-        bottom: 0rem;
-        transform: translateX(-50%) translateY(-50%);
-        color: #b10a0a;
-        @include text-line(1, 1.2rem);
+        top: 50%;
+        transform: translateY(-50%);
+        right: 4.5rem;
+        display: flex;
+        border-radius: 100%;
+        &:hover {
+          background-color: rgba(0, 0, 0, 0.2);
+        }
+      }
 
-        &:before {
-          content: '* ';
+      button[type='submit'] {
+        position: absolute;
+        right: 1.5rem;
+        top: 50%;
+        transform: translateY(-50%);
+        display: flex;
+        padding: 0.5rem;
+        border-radius: 100%;
+        background-color: map-get($colors, salmon);
+        color: map-get($colors, light-font);
+        @include transition(background-color, 80ms, $bezier-curve);
+        @include box-shadow();
+
+        &:hover {
+          background-color: map-get($colors, hover-salmon);
         }
       }
     }
-  }
 
-  .result {
-    & > div {
-      width: 75%;
-      margin: auto;
-      padding: 2rem 1rem;
-      background-color: map-get($colors, card-bg);
-      border-radius: 10px;
-      @include box-shadow();
+    p {
+      position: absolute;
+      left: 50%;
+      bottom: 0rem;
+      transform: translateX(-50%) translateY(-50%);
+      color: #b10a0a;
+      @include text-line(1, 1.2rem);
 
-      p {
-        text-align: center;
-        font-size: 1.25rem;
-        font-weight: 500;
-        @include text-line(1, 1.5rem);
+      &:before {
+        content: '* ';
       }
     }
   }
+}
 
-  .content-section {
-    @extend %section-layout;
+.result {
+  padding: 0.5rem;
 
-    & > div {
-      @extend %section-header;
-    }
+  & > div {
+    width: 75%;
+    margin: auto;
+    padding: 2rem 1rem;
+    background-color: rgba(map-get($colors, card-bg), 75%);
+    border-radius: 10px;
+    @include box-shadow();
 
-    section {
-      @extend %home-contents-section;
+    p {
+      text-align: center;
+      font-size: 1.25rem;
+      font-weight: 500;
+      @include text-line(1, 1.5rem);
     }
   }
+}
 
-  .channel-section {
-    @extend %section-layout;
+.content-section {
+  @extend %section-layout;
 
-    & > div {
-      @extend %section-header;
-    }
+  & > div {
+    @extend %section-header;
+  }
 
-    section {
-      @extend %channels-channel-section;
-    }
+  section {
+    @extend %home-contents-section;
+    margin: 1.5rem 0;
+  }
+}
+
+.channel-section {
+  @extend %section-layout;
+
+  & > div {
+    @extend %section-header;
+  }
+
+  section {
+    @extend %channels-channel-section;
+    margin: 1.5rem 0;
   }
 }


### PR DESCRIPTION
유투브 카드 
- sm point이상일때 너비 고정
- scale, gap 사이즈 조정

채널 카드
- 950px 이상일때 너비 고정, grid column을 3개로
- 2xl point에서 column을 4개로

각 페이지 main section을 지우고 main .app 하나로 스타일 통합

reset.css 추가

페이지네이션 컴포넌트 
- 기본 padding 0.25rem로 축소
- flex-wrap 추가, 화면이 작아질때 줄변경

홈페이지
- navLink button 태그 제거
- line-height 2.4rem으로 고정

검색페이지
- 검색결과 배경 투명도 조절
- 섹션 padding을 없애고 x축 margin으로 변경
- sm point이하일때 section을 100% 늘려서 유투브 컨텐츠, 채널  섹션 너비를 동일하게 맞춤