### PR TITLE
Update: md 브레이크포인트 이상에서 NavSection이 sticky가 아니게 변경

### DIFF
--- a/components/home/Home.module.scss
+++ b/components/home/Home.module.scss
@@ -13,6 +13,7 @@
   padding: 0.5rem;
 
   @include min-width(map-get($points, md)) {
+    position: inherit;
     padding: 1rem;
   }
 


### PR DESCRIPTION
유튜브 플레이어가 NavSection에 의해 가려지는 문제

수정 전

![스크린샷 2024-01-22 002150](https://github.com/yiminwook/liveuta/assets/97679910/7ded19f9-5019-439e-9900-10317e4bb236)
