### PR TITLE
Refactor MongoDB Push Operations in API Endpoint

### DIFF
--- a/app/api/mongoDBService/route.ts
+++ b/app/api/mongoDBService/route.ts
@@ -68,23 +68,20 @@ export const POST = async (req: NextRequest) => {
     const notiCollection = process.env.MONGODB_NOTI_COLLECTION;
     const notiDatabase = process.env.MONGODB_SCHEDULE_DB;
 
-    // if (!notiCollection || !notiDatabase) {
-    //   throw new Error('MongoDB collection or database names are not defined in environmental variables.');
-    // }
+    if (!notiCollection || !notiDatabase) {
+      throw new Error('MongoDB collection or database names are not defined in environmental variables.');
+    }
 
-    // const existingData = await readDB(notiCollection, notiDatabase, {
-    //   filter: { token: requestBody.token, link: requestBody.link },
-    // });
+    const existingData = await readDB(notiCollection, notiDatabase, {
+      filter: { token: requestBody.token, link: requestBody.link },
+    });
 
-    // console.log('existingData', existingData);
+    if (existingData && existingData.documents && existingData.documents.length !== 0) {
+        return NextResponse.json({ message: '이미 등록된 알림입니다.' }, { status: 226 });
+    }
 
-    // if (existingData) {
-    //   return NextResponse.json({ message: '이미 등록된 알림입니다.' }, { status: 226 });
-    // }
+    await writeDB(notiCollection, notiDatabase, { document: requestBody });
 
-    const res = await writeDB(notiCollection, notiDatabase, { document: requestBody });
-
-    console.log('res', res);
     return NextResponse.json({ message: '알림이 성공적으로 등록되었습니다.' }, { status: 201 });
   } catch (error) {
     // console.error(error);

--- a/models/mongoDBService/index.ts
+++ b/models/mongoDBService/index.ts
@@ -3,7 +3,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 interface PerformDatabaseOptions {
   collection: string;
   database: string;
-  operation: 'find' | 'insert';
+  operation: 'find' | 'insertOne';
   filter?: any;
   projection?: any;
   document?: any;
@@ -70,7 +70,7 @@ export const writeDB = async (collection: string, database: string, options?: { 
   return performDatabaseOperation({
     collection,
     database,
-    operation: 'insert',
+    operation: 'insertOne',
     document: options?.document,
   });
 };


### PR DESCRIPTION
Corrected API endpoint from 'insert' to 'insertOne in models/mongoDBService/index.ts

Ensure 'existingData' contains 'document' and validate its length in app/api/mongoDBService/route.ts