### PR TITLE
Liveuta translation revision

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -166,7 +166,7 @@
       "navigationChannel": "Search by Channel"
     },
     "sliderCard": {
-      "alarm": "Set Alarm",
+      "alarm": "Set Notification",
       "addMultiView": "Add to MultiView",
       "favorite": "Favorites",
       "remove": "Remove",
@@ -274,7 +274,7 @@
     },
     "scheduleCard": {
       "imageAlt": "Livestream",
-      "setAlarm": "Set Alarm",
+      "setAlarm": "Set Notification",
       "addMultiView": "Add to MultiView",
       "favorite": "Favorites",
       "blockChannel": "Block Channel",
@@ -284,7 +284,7 @@
         "livestreamOf": "'s stream"
       },
       "cardMenu": {
-        "setAlarm": "Set Alarm",
+        "setAlarm": "Set Notification",
         "addMultiView": "Add to MultiView",
         "favorite": "Favorites",
         "add": "Add",

--- a/messages/jp.json
+++ b/messages/jp.json
@@ -160,7 +160,7 @@
       "navigationChannel": "チャンネルで検索"
     },
     "sliderCard": {
-      "alarm": "アラーム設定",
+      "alarm": "通知設定",
       "addMultiView": "マルチビュー追加",
       "favorite": "お気に入り",
       "remove": "解除",
@@ -268,7 +268,7 @@
     },
     "scheduleCard": {
       "imageAlt": "の配信",
-      "setAlarm": "アラーム設定",
+      "setAlarm": "通知設定",
       "addMultiView": "マルチビュー追加",
       "favorite": "お気に入り",
       "blockChannel": "チャンネルをブロック",
@@ -278,7 +278,7 @@
         "livestreamOf": "の放送"
       },
       "cardMenu": {
-        "setAlarm": "アラーム設定",
+        "setAlarm": "通知設定",
         "addMultiView": "マルチビュー追加",
         "favorite": "お気に入り",
         "add": "追加",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -401,7 +401,7 @@
     "title": "설정",
     "autoSync": {
       "title": "자동 동기화",
-      "onLabel": "시용",
+      "onLabel": "사용",
       "offLabel": "사용 안 함",
       "refreshInterval": "새로고침 간격",
       "unit": "분"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -166,7 +166,7 @@
       "navigationChannel": "채널로 검색"
     },
     "sliderCard": {
-      "alarm": "알람 설정",
+      "alarm": "알림 설정",
       "addMultiView": "멀티뷰 추가",
       "favorite": "즐겨찾기",
       "remove": "해제",
@@ -274,7 +274,7 @@
     },
     "scheduleCard": {
       "imageAlt": "의 라이브방송",
-      "setAlarm": "알람 설정",
+      "setAlarm": "알림 설정",
       "addMultiView": "멀티뷰 추가",
       "favorite": "즐겨찾기",
       "blockChannel": "채널 차단",
@@ -284,7 +284,7 @@
         "livestreamOf": "의 방송"
       },
       "cardMenu": {
-        "setAlarm": "알람 설정",
+        "setAlarm": "알림 설정",
         "addMultiView": "멀티뷰 추가",
         "favorite": "즐겨찾기",
         "add": "추가",


### PR DESCRIPTION
한영일 모두 notification과 alarm이 일부 혼용되어 있는데 의미상 notification이 더 적절할 것 같아서 일괄로 통일함. 추가로, setAlarm 등도 전부 setNotification으로 바꿨으면 싶긴 한데 일단 이건 패스....

그리고 바꾸진 않았는데 '채널등록' 관련이 좀 신경쓰여서 의견을 물어보고싶은데... 한국어로는 크게 이상하다고 생각 하지 않을 수 있는데 일단 일본어로 하면 채널 등록 = 구독 같은 느낌이 돼서 피하고싶고, 그러면 '채널 추가' 정도로 쓸 수 있을 거 같음. by registration 같은 것도 added order 처럼 다소 캐주얼하게 바꾸고 싶은데 (context상 큰 문제는 없겠지만 by registration이 여러 의미로 해석 될 수 있기도 하고) 이 경우에는 alphabetical 이랑 직접 대응 되지 않는 느낌이 커져서 (alphabetical order vs. added order가 아니라 alphabetical vs. added order가 되니까... 안되는건 아니지만)  ABC order/Added order 같은게 되지 않을라나

+ 하는김에 ko에서 오타 하나 보여서 고쳤음... 
+ squash는 알아서 해주는거...지?